### PR TITLE
changed the SetDefaultBootOrderActionInfo parameters type from Array to Object Array

### DIFF
--- a/svc-aggregation/rpc/aggregator.go
+++ b/svc-aggregation/rpc/aggregator.go
@@ -974,7 +974,7 @@ func (a *Aggregator) GetSetDefaultBootOrderActionInfo(ctx context.Context, req *
 			{
 				Name:     "Systems",
 				Required: true,
-				DataType: "Array",
+				DataType: "ObjectArray",
 			},
 		},
 		OdataID: "/redfish/v1/AggregationService/SetDefaultBootOrderActionInfo",


### PR DESCRIPTION
Issue: Service Validator (2021.2-Schema)- "/redfish/v1/AggregationService/SetDefaultBootOrderActionInfo"
ERROR - DataType: Value Array Enum not found in ['Boolean', 'Number', 'NumberArray', 'String', 'StringArray', 'Object', 'ObjectArray']

To fix this changed array in response to Object Array