### PR TITLE
Added config parameters for imageregistery and fixed issue with loglevel  in helm charts

### DIFF
--- a/lib-utilities/config/config.go
+++ b/lib-utilities/config/config.go
@@ -65,6 +65,7 @@ type configModel struct {
 	RequestLimitCountPerSession    int                      `json:"RequestLimitCountPerSession"`
 	SessionLimitCountPerUser       int                      `json:"SessionLimitCountPerUser"`
 	LogLevel                       log.Level                `json:"LogLevel"`
+	ImageRegistryAddress           string                   `json:"ImageRegistryAddress,omitempty"`
 }
 
 // DBConf holds all DB related configurations

--- a/lib-utilities/config/odimra_config.json
+++ b/lib-utilities/config/odimra_config.json
@@ -144,5 +144,6 @@
   "ResourceRateLimit": [],
   "RequestLimitPerSession":0,
   "SessionLimitPerUser":0,
-  "LogLevel":"warn"
+  "LogLevel":"warn",
+  "ImageRegistryAddress":""
 }

--- a/odim-controller/helmcharts/odimra-config/templates/configmaps.yaml
+++ b/odim-controller/helmcharts/odimra-config/templates/configmaps.yaml
@@ -144,6 +144,7 @@ data:
       },
       "ResourceRateLimit": {{ .Values.odimra.resourceRateLimit | toJson }},
       "LogLevel": {{ .Values.odimra.logLevel | quote }},
+      "ImageRegistryAddress": {{ .Values.odimra.imageRegistryAddress | quote }},
       "RequestLimitCountPerSession": {{ .Values.odimra.requestLimitPerSession | default 0 }},
       "SessionLimitCountPerUser": {{ .Values.odimra.sessionLimitPerUser | default 0 }}
     }

--- a/odim-controller/helmcharts/odimra-config/values.yaml
+++ b/odim-controller/helmcharts/odimra-config/values.yaml
@@ -5,3 +5,4 @@ odimra:
   apiGatewayHost: 
   connectionMethodConf:
   haDeploymentEnabled:
+  logLevel:

--- a/odim-controller/scripts/odim-controller.py
+++ b/odim-controller/scripts/odim-controller.py
@@ -177,7 +177,7 @@ def perform_checks(skip_opt_param_check=False):
 	DEPLOYMENT_ID = CONTROLLER_CONF_DATA['deploymentID']
 	if 'logLevel' not in CONTROLLER_CONF_DATA['odimra'] or CONTROLLER_CONF_DATA['odimra']['logLevel'] == None or CONTROLLER_CONF_DATA['odimra']['logLevel'] == "": 
 		logger.critical("Log level is not set, Setting default value warn")
-		CONTROLLER_CONF_DATA['logLevel']="warn"
+		CONTROLLER_CONF_DATA['odimra']['logLevel']="warn"
 	else :
 		log_levels = ['panic', 'fatal', 'error', 'warn','info','debug','trace']
 		if CONTROLLER_CONF_DATA['odimra']['logLevel'] not in log_levels:


### PR DESCRIPTION
ODIM RHOCP deployment is failing due to the missing configurations.
To fix this Added config parameters for imageregistery and fixed issue with loglevel  in helm charts